### PR TITLE
remove trailing space in ref tuple  file

### DIFF
--- a/doc/simastrom.tex
+++ b/doc/simastrom.tex
@@ -181,7 +181,7 @@ are displayed in figure \ref{fig:AssocClasses}.
 \subsection{Least-squares expression}
 The fit consists of minimizing:
 \begin{align}
-\chi^2 & =  \sum_{\gamma,i}  [M_\gamma(X_{\gamma,i})-P_{\gamma}(F_j) ]^T W_{\gamma,i}  [M_\gamma(X_{\gamma,i})-P_{\gamma}(F_k) ] & \textrm{(meas. terms)} \nonumber \\
+\chi^2 & =  \sum_{\gamma,i}  [M_\gamma(X_{\gamma,i})-P_{\gamma}(F_i) ]^T W_{\gamma,i}  [M_\gamma(X_{\gamma,i})-P_{\gamma}(F_i) ] & \textrm{(meas. terms)} \nonumber \\
          &+\sum_j [P(F_j)-P(R_j)]^T W_j [P(F_j)-P(R_j)] & \textrm{(ref. terms)} \label{eq:chi2}
 \end{align}
 where the first line iterates on all MeasuredStar ($i$) from all

--- a/doc/simastrom.tex
+++ b/doc/simastrom.tex
@@ -167,7 +167,7 @@ The \ClName{Associations} class holds the list of input
 \ClName{CcdImage's} and connects together the measurements of the same
 object. The input measurements are called \ClName{MeasuredStar} and
 the common detections are called \ClName{FittedStar}. The objects
-collected in an external catalog are called\ClName{RefStar}
+collected in an external catalog are called \ClName{RefStar}.
 Despite their
 names, these classes can represent galaxies as well as stars. The
 collections of sush objects are stored into \ClName{MeasuredStarList},

--- a/src/AstromFit.cc
+++ b/src/AstromFit.cc
@@ -1046,8 +1046,7 @@ void AstromFit::MakeRefResTuple(const std::string &TupleName) const
 	    << fs.color << ' ' 
 	    << fs.IndexInMatrix() << ' '
 	    << chi2 << ' ' 
-	    << fs.MeasurementCount() << ' '
-	    << endl;
+	    << fs.MeasurementCount() << endl;
     }// loop on FittedStars
 }
 


### PR DESCRIPTION
This way python parsing of both files is identical for panda for instance
